### PR TITLE
Added cup and pint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ People are blaming recent airplane tragedies on a confusion between the imperial
 | Baking soda (in a recipe) | Teaspoons
 | Butter (in a store) | 454g packages
 | Butter (in a recipe) | Cups
+| Cup (metric) | 250ml
 | Temperature (outside) | Degrees Celsius
 | Temperature (in an oven) | Degrees Fahrenheit 
 | Temperature (of a swimming pool) | Degrees Fahrenheit 
@@ -46,8 +47,9 @@ People are blaming recent airplane tragedies on a confusion between the imperial
 | Wine (glass of) | Ounces
 | Beer (bottle) | 341 millilitres
 | Beer (can) | 355 millimetres
-| Beer (draught) | Pint
+| Beer (draught) | Pint (imperial)
 | Beer (bulk, 24-can case) | “Two fours”
+| Pint (imperial) | 568 ml
 | Wrench (that you have) | Inches
 | Wrench (that you need) | Centimetres
 


### PR DESCRIPTION
Just wanted to amend two different types of measurement because oddly enough we use the metric cup and imperial pint. 

In the metric system of measurement one cup is defined as 250ml rather than in the US system where it is 8oz (236ml) or 240ml for legal purposes. While it's not a huge change, it's a frustrating difference when making large recopies which have no clear indicator as to which system of measurement they've used. 

Similarly, with the pint, Canada uses the old English imperial pint which is 568ml as opposed to the American pint which is 16 oz (473 mL). Some Ontario border towns I've been into do serve the American Pint however most Canadian bars will serve an imperial pint. The size difference for this one is also very noticeable.
